### PR TITLE
Prepare v3.1.3 beta release

### DIFF
--- a/VrcTwitchOscBridge/VrcTwitchOscBridge.csproj
+++ b/VrcTwitchOscBridge/VrcTwitchOscBridge.csproj
@@ -11,10 +11,10 @@
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
     <ApplicationIcon>Assets\crystal-relay-icon.ico</ApplicationIcon>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>3.1.2</Version>
-    <AssemblyVersion>3.1.2.0</AssemblyVersion>
-    <FileVersion>3.1.2.0</FileVersion>
-    <InformationalVersion>3.1.2</InformationalVersion>
+    <Version>3.1.3</Version>
+    <AssemblyVersion>3.1.3.0</AssemblyVersion>
+    <FileVersion>3.1.3.0</FileVersion>
+    <InformationalVersion>3.1.3</InformationalVersion>
     <AssemblyName>CrystalRelayTwitchOsc</AssemblyName>
     <Product>Crystal Relay</Product>
     <Title>Crystal Relay - Twitch to OSC</Title>


### PR DESCRIPTION
Summary:
- Bump Crystal Relay version metadata to 3.1.3 for beta 1.

Validation:
- Public safety preflight passed locally.
- Release build passed locally.
- git diff --check passed.